### PR TITLE
Add orderby to threads query in space screen and follow up screen

### DIFF
--- a/src/Components/SpaceThreads.js
+++ b/src/Components/SpaceThreads.js
@@ -51,28 +51,28 @@ function SpaceThreads(props) {
         />
         <StyledButtonsContainer>
           <StyledDropdown>
-            <Dropdown icon='ellipsis horizontal'>
+            <Dropdown icon="ellipsis horizontal">
               <Dropdown.Menu>
                 {localStorage.getItem('uuid') === props.space.spaceCreatedByUserId && (
                   <Dropdown.Item
-                    text='Edit space'
-                    onClick={(e) => {
+                    text="Edit space"
+                    onClick={e => {
                       props.showModal('EditSpaceModal');
                     }}
                   />
                 )}
                 {localStorage.getItem('uuid') === props.space.spaceCreatedByUserId && (
                   <Dropdown.Item
-                    text='Delete space'
-                    onClick={(e) => {
+                    text="Delete space"
+                    onClick={e => {
                       props.showModal('DeleteSpaceModal');
                     }}
                   />
                 )}
                 {localStorage.getItem('uuid') !== props.space.spaceCreatedByUserId && (
                   <Dropdown.Item
-                    text='Leave space'
-                    onClick={(e) => {
+                    text="Leave space"
+                    onClick={e => {
                       props.showModal('LeaveSpaceModal');
                     }}
                   />
@@ -82,25 +82,26 @@ function SpaceThreads(props) {
           </StyledDropdown>
 
           <ScreenButton
-            content='Start a thread'
+            content="Start a thread"
             icon={penIconWhite}
-            backgroundColor='#00bc98'
-            color='white'
-            border='none'
-            onClick={(e) => {
+            backgroundColor="#00bc98"
+            color="white"
+            border="none"
+            onClick={e => {
               props.showModal('CreateThreadModal');
             }}
           />
         </StyledButtonsContainer>
       </StyledFirstRow>
-      <ScreenSectionHeading heading='Recent' />
+      <ScreenSectionHeading heading="Recent" />
 
       {/*Loop trough all the threads that are associated with the orgId*/}
       {props.threads.length > 0 &&
-        props.threads.map((t) => {
+        props.threads.map(t => {
           let dateInfo = new Date(t.threadCreatedAt);
-          let date = `${dateInfo.getDate()}/${dateInfo.getMonth()}/${dateInfo.getFullYear()} at ${dateInfo.getHours()}:${('0' +
-            dateInfo.getMinutes()).slice(-2)}`;
+          let date = `${dateInfo.getDate()}/${dateInfo.getMonth()}/${dateInfo.getFullYear()} at ${dateInfo.getHours()}:${(
+            '0' + dateInfo.getMinutes()
+          ).slice(-2)}`;
 
           return (
             <ThreadCard
@@ -175,7 +176,7 @@ const StyledDropdown = styled.div`
   }
 `;
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     auth: state.firebase.auth,
     profile: state.firebase.profile,
@@ -187,17 +188,21 @@ const mapStateToProps = (state) => {
   };
 };
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return bindActionCreators({ showModal, setActiveThread }, dispatch);
 };
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps),
-  firestoreConnect((props) => {
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  ),
+  firestoreConnect(props => {
     return [
       {
         collection: 'threads',
-        where: [ 'spaceId', '==', props.spaceId ]
+        where: ['spaceId', '==', props.spaceId],
+        orderBy: ['threadCreatedAt', 'desc']
       },
       {
         collection: 'spaces',

--- a/src/Components/reusable-components/FollowUp.js
+++ b/src/Components/reusable-components/FollowUp.js
@@ -71,7 +71,8 @@ export default compose(
     return [
       {
         collection: 'threads',
-        where: [['isFollowUp', '==', true], ['arrayOfUserIdsWhoFollowUp', 'array-contains', props.uuid]]
+        where: [['isFollowUp', '==', true], ['arrayOfUserIdsWhoFollowUp', 'array-contains', props.uuid]],
+        orderBy: ['threadCreatedAt', 'desc']
       }
     ];
   })


### PR DESCRIPTION
# Description

Add orderby to threads query in space screen and follow up screen:
![image](https://user-images.githubusercontent.com/30407135/58277646-7998bf80-7d9a-11e9-800d-d690881491e2.png)
![image](https://user-images.githubusercontent.com/30407135/58277670-8ddcbc80-7d9a-11e9-90d9-b6e89fce59c9.png)



## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe steps taken to ensure this feature is functional and does not break other features:

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if relevant
- [ ] I have run the app using my feature and ensured that no functionality is broken
- [ ] My changes generate no new warnings
- [ ] There are no merge conflicts
