### PR TITLE
Add media queries for mobile

### DIFF
--- a/src/Components/Login.js
+++ b/src/Components/Login.js
@@ -128,7 +128,7 @@ class Login extends Component {
           <StyledH1>Sign in</StyledH1>
           <StyledForm onSubmit={this.handleLogIn}>
             <StyledLabel>
-              <StyledPLabel>Email Address</StyledPLabel>
+              <StyledPLabel>Email</StyledPLabel>
               <StyledInput
                 name="loginEmail"
                 value={this.state.loginEmail}

--- a/src/Components/styled-components/StyledButton.js
+++ b/src/Components/styled-components/StyledButton.js
@@ -12,6 +12,10 @@ export const StyledButton = styled.button`
   &:disabled {
     background-color: lightgray;
   }
+  @media screen and (max-width: 500px) {
+    width: 90px;
+    font-size: 1rem;
+  }
 `;
 
 export const ForgotPasswordDiv = styled.div`

--- a/src/Components/styled-components/StyledLogin.js
+++ b/src/Components/styled-components/StyledLogin.js
@@ -26,6 +26,10 @@ export const StyledForm = styled.form`
   -webkit-box-shadow: 0px 15px 35px -34px rgba(92, 92, 91, 1);
   -moz-box-shadow: 0px 15px 35px -34px rgba(92, 92, 91, 1);
   box-shadow: 0px 15px 35px -34px rgba(92, 92, 91, 1);
+  @media screen and (max-width: 500px) {
+    max-width: 95vw;
+    font-size: 1rem;
+  }
 `;
 
 export const StyledInput = styled.input`


### PR DESCRIPTION
# Description

Add media queries for mobile phones (500px and smaller), so the login and register form fits the screen.
![image](https://user-images.githubusercontent.com/30407135/58323557-9e397980-7e24-11e9-8ebb-fe35a26ca192.png)

Renamed Email Address to Email  for consistency between register nad login. Plus itfits the smaller screens better. 
![image](https://user-images.githubusercontent.com/30407135/58323591-b9a48480-7e24-11e9-99b1-bc5ecdfa72e0.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe steps taken to ensure this feature is functional and does not break other features:

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if relevant
- [ ] I have run the app using my feature and ensured that no functionality is broken
- [ ] My changes generate no new warnings
- [ ] There are no merge conflicts
