### PR TITLE
Fix the bug where when you have multiple windows open the heart is st…

### DIFF
--- a/src/Components/reusable-components/CommentCardComponents/CommentCard.js
+++ b/src/Components/reusable-components/CommentCardComponents/CommentCard.js
@@ -18,15 +18,8 @@ const CommentCard = props => {
   // use context api
   const { updateDataWithDoc, deleteData, firebase } = useContext(Context);
 
-  const [didUserLikeComment, setDidUserLikeComment] = useState(
-    props.arrayOfUsersWhoLiked.includes(localStorage.getItem('uuid'))
-  );
   const [isUpdating, setUpdating] = useState(false);
   const [isHovering, setHovering] = useState(false);
-
-  const toggleLikePhoto = () => {
-    setDidUserLikeComment(prevState => !prevState);
-  };
 
   const deleteComment = id => {
     let request = {
@@ -102,12 +95,13 @@ const CommentCard = props => {
             )}
             {gifUrl && <GifInComment src={gifUrl} alt="gif" />}
             <StyledLikesContainer>
-              {!didUserLikeComment && (
+              {!props.arrayOfUsersWhoLiked.includes(
+                localStorage.getItem('uuid')
+              ) && (
                 <img
                   src={heartIconBlack}
                   alt="heart icon"
                   onClick={() => {
-                    toggleLikePhoto();
                     let request = {
                       collection: 'comments',
                       docId: commentId,
@@ -121,15 +115,17 @@ const CommentCard = props => {
                   }}
                 />
               )}
-              {!didUserLikeComment && likes !== 0 && (
-                <div className="black-likes">{likes}</div>
-              )}
-              {didUserLikeComment && (
+              {!props.arrayOfUsersWhoLiked.includes(
+                localStorage.getItem('uuid')
+              ) &&
+                likes !== 0 && <div className="black-likes">{likes}</div>}
+              {props.arrayOfUsersWhoLiked.includes(
+                localStorage.getItem('uuid')
+              ) && (
                 <img
                   src={heartIconRed}
                   alt="heart icon"
                   onClick={() => {
-                    toggleLikePhoto();
                     let request = {
                       collection: 'comments',
                       docId: commentId,
@@ -143,7 +139,9 @@ const CommentCard = props => {
                   }}
                 />
               )}
-              {didUserLikeComment && <div className="red-likes">{likes}</div>}
+              {props.arrayOfUsersWhoLiked.includes(
+                localStorage.getItem('uuid')
+              ) && <div className="red-likes">{likes}</div>}
             </StyledLikesContainer>
           </StyledRightContainer>
         )}


### PR DESCRIPTION
Fixed a bug that happens when you have multiple windows open and like a comment that the heart is not red on the other screen. Same with unliking.

# Description

Please include a summary of the change and a link to which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status

- [ ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe steps taken to ensure this feature is functional and does not break other features:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if relevant
- [ ] I have run the app using my feature and ensured that no functionality is broken
- [ ] My changes generate no new warnings
- [ ] There are no merge conflicts
